### PR TITLE
add feature to direct the game to a specific scene after the loading screen

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,0 +1,25 @@
+export function setSceneToLoad(scriptName) {
+
+    const content = std.loadFile("src/Configuration Files/config.json");
+
+    const file = std.open("src/Configuration Files/config.json", "w");
+
+    let newJSON = JSON.parse(content);
+
+    newJSON.sceneToLoad = "src/Scenes/" + scriptName;
+
+    file.puts(JSON.stringify(newJSON));
+    file.flush();
+    file.close();
+}
+
+export function getSceneToLoad() {
+
+    let sceneToLoad;
+
+    const content = std.loadFile("src/Configuration Files/config.json");
+
+    sceneToLoad = JSON.parse(content).sceneToLoad;
+
+    return sceneToLoad;
+}

--- a/src/Configuration Files/config.json
+++ b/src/Configuration Files/config.json
@@ -1,1 +1,1 @@
-{"audio":{"mainVolume":"unknown","soundEffects":"unknown","music":"unknown"}}
+{"audio":{"mainVolume":"unknown","soundEffects":"unknown","music":"unknown"},"sceneToLoad":"src/Scenes/Inkwell Isle One/main.js"}

--- a/src/Scenes/Hourglass/loading.js
+++ b/src/Scenes/Hourglass/loading.js
@@ -1,3 +1,4 @@
+import { getSceneToLoad } from "../../../env.js";
 import { FadeIn, FadeOut } from "/src/Modules/fade.js";
 
 const font = new Font("default");
@@ -63,6 +64,6 @@ Screen.display(() => {
     }
 
     if (currentTime - startTime >= reloadTime2) {
-        std.reload("src/Scenes/Inkwell Isle One/main.js");
+        std.reload(getSceneToLoad());
     }
 });

--- a/src/Scenes/StoryBook/book.js
+++ b/src/Scenes/StoryBook/book.js
@@ -1,3 +1,4 @@
+import { setSceneToLoad } from "../../../env.js";
 import { FadeIn, FadeOut } from "/src/Modules/fade.js";
 
 let currentPage = 1;
@@ -168,6 +169,7 @@ let currentUpdater = null;
 Screen.display(() => {
 
     if (currentPage > 11) {
+        setSceneToLoad("Inkwell Isle One/main.js")
         std.reload("src/Scenes/Hourglass/loading.js");
     }
 
@@ -180,4 +182,3 @@ Screen.display(() => {
         currentUpdater = animatePage(images, arrow, config.text);
     }
 });
-


### PR DESCRIPTION
env.js now has a function to set the next scene that will be loaded upon loading and also a function to get the name of the scene that needs to be loaded, saving this in config.json